### PR TITLE
Allow function app package filesystem writes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,6 @@ resource "azurerm_windows_function_app" "wfa" {
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME = "node"
-    WEBSITE_RUN_FROM_PACKAGE = "0"
   }
 
   identity {
@@ -85,7 +84,7 @@ resource "azurerm_windows_function_app" "wfa" {
 resource "azurerm_function_app_function" "faf" {
   name            = local.function_name
   function_app_id = azurerm_windows_function_app.wfa.id
-  language        = "JavaScript"
+  language        = "Javascript"
 
   file {
     name    = "index.js"


### PR DESCRIPTION
## Summary
- remove the WEBSITE_RUN_FROM_PACKAGE app setting so the Windows Function App keeps a writable filesystem
- adjust the Azure Function resource language value to match Terraform's expected casing

## Testing
- `terraform apply -auto-approve -var "name_function=testfunc"` *(fails: Azure CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e469495f2c832193abb4f52515e1ca